### PR TITLE
Docs: recommend using the regular es2015 preset [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ It uses the [rollup-plugin-memory](https://github.com/TrySound/rollup-plugin-mem
   rollup: [
     require('rollup-plugin-babel')({
       exclude: 'node_modules/**',
-      preset: ['es2015-rollup']
+      preset: [
+        ['es2015', { modules: false }]
+      ]
     })
   ]
 }


### PR DESCRIPTION
Unless we are more comfortable recommending https://github.com/babel/babel-preset-env instead (I'd rather do that).

If so, just need to replace `es2015` with `env`